### PR TITLE
Remove OSVDB references

### DIFF
--- a/modules/auxiliary/download_manager_privilege_escalation.rb
+++ b/modules/auxiliary/download_manager_privilege_escalation.rb
@@ -18,7 +18,6 @@ class Wpxf::Auxiliary::DownloadManagerPrivilegeEscalation < Wpxf::Module
       ],
       references: [
         ['EDB', '35533'],
-        ['OSVDB', '115287'],
         ['WPVDB', '7706']
       ],
       date: 'Dec 3 2014'

--- a/modules/auxiliary/long_password_dos.rb
+++ b/modules/auxiliary/long_password_dos.rb
@@ -20,7 +20,6 @@ class Wpxf::Auxiliary::LongPasswordDos < Wpxf::Module
       ],
       references: [
         ['CVE', '2014-9034'],
-        ['OSVDB', '114857'],
         ['WPVDB', '7681'],
         ['URL', 'http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9034']
       ],

--- a/modules/exploits/advanced_custom_fields_remote_file_inclusion.rb
+++ b/modules/exploits/advanced_custom_fields_remote_file_inclusion.rb
@@ -16,7 +16,6 @@ class Wpxf::Exploit::AdvancedCustomFieldsRemoteFileInclusion < Wpxf::Module
         'Rob Carr <rob[at]rastating.com>'            # WPXF module
       ],
       references: [
-        ['OSVDB', '87353'],
         ['URL', 'http://secunia.com/advisories/51037/'],
         ['WPVDB', '6103']
       ],

--- a/modules/exploits/charity_theme_shell_upload.rb
+++ b/modules/exploits/charity_theme_shell_upload.rb
@@ -19,7 +19,6 @@ class Wpxf::Exploit::CharityThemeShellUpload < Wpxf::Exploit::SimplecartShellUpl
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '121441'],
         ['EDB', '36611']
       ],
       date: 'April 02 2015'

--- a/modules/exploits/creative_contact_form_shell_upload.rb
+++ b/modules/exploits/creative_contact_form_shell_upload.rb
@@ -16,7 +16,6 @@ class Wpxf::Exploit::CreativeContactFormShellUpload < Wpxf::Module
       ],
       references: [
         ['EDB', '35057'],
-        ['OSVDB', '113669'],
         ['WPVDB', '7652']
       ],
       date: 'Oct 22 2014'

--- a/modules/exploits/easy_cart_shell_upload.rb
+++ b/modules/exploits/easy_cart_shell_upload.rb
@@ -29,7 +29,6 @@ class Wpxf::Exploit::EasyCartShellUpload < Wpxf::Module
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '116806'],
         ['WPVDB', '7745']
       ],
       date: 'Jan 08 2015'

--- a/modules/exploits/evo_theme_shell_upload.rb
+++ b/modules/exploits/evo_theme_shell_upload.rb
@@ -19,7 +19,6 @@ class Wpxf::Exploit::EvoThemeShellUpload < Wpxf::Exploit::SimplecartShellUpload
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '121441'],
         ['EDB', '36611']
       ],
       date: 'April 02 2015'

--- a/modules/exploits/gallery_pro_theme_shell_upload.rb
+++ b/modules/exploits/gallery_pro_theme_shell_upload.rb
@@ -19,7 +19,6 @@ class Wpxf::Exploit::GalleryProThemeShellUpload < Wpxf::Exploit::SimplecartShell
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '121441'],
         ['EDB', '36611']
       ],
       date: 'April 02 2015'

--- a/modules/exploits/inboundio_marketing_shell_upload.rb
+++ b/modules/exploits/inboundio_marketing_shell_upload.rb
@@ -16,7 +16,6 @@ class Wpxf::Exploit::InboundioMarketingShellUpload < Wpxf::Module
       ],
       references: [
         ['EDB', '36478'],
-        ['OSVDB', '119890'],
         ['WPVDB', '7864']
       ],
       date: 'Mar 24 2015'

--- a/modules/exploits/micro_theme_shell_upload.rb
+++ b/modules/exploits/micro_theme_shell_upload.rb
@@ -19,7 +19,6 @@ class Wpxf::Exploit::MicroThemeShellUpload < Wpxf::Exploit::SimplecartShellUploa
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '121441'],
         ['EDB', '36611']
       ],
       date: 'April 02 2015'

--- a/modules/exploits/photo_gallery_shell_upload.rb
+++ b/modules/exploits/photo_gallery_shell_upload.rb
@@ -20,7 +20,6 @@ class Wpxf::Exploit::PhotoGalleryShellUpload < Wpxf::Module
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '117676'],
         ['WPVDB', '7769'],
         ['CVE', '2014-9312'],
         ['URL', 'http://security.szurek.pl/photo-gallery-125-unrestricted-file-upload.html']

--- a/modules/exploits/reflex_gallery_shell_upload.rb
+++ b/modules/exploits/reflex_gallery_shell_upload.rb
@@ -17,7 +17,6 @@ class Wpxf::Exploit::ReflexGalleryShellUpload < Wpxf::Module
       ],
       references: [
         ['EDB', '36374'],
-        ['OSVDB', '88853'],
         ['WPVDB', '7867']
       ],
       date: 'March 16 2015'

--- a/modules/exploits/revslider_shell_upload.rb
+++ b/modules/exploits/revslider_shell_upload.rb
@@ -15,7 +15,6 @@ class Wpxf::Exploit::RevsliderShellUpload < Wpxf::Module
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '115118'],
         ['EDB', '35385'],
         ['WPVDB', '7954'],
         ['URL', 'https://whatisgon.wordpress.com/2014/11/30/another-revslider-vulnerability/']

--- a/modules/exploits/simplecart_shell_upload.rb
+++ b/modules/exploits/simplecart_shell_upload.rb
@@ -19,7 +19,6 @@ class Wpxf::Exploit::SimplecartShellUpload < Wpxf::Module
         'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-        ['OSVDB', '121441'],
         ['EDB', '36611']
       ],
       date: 'April 02 2015'

--- a/modules/exploits/symposium_shell_upload.rb
+++ b/modules/exploits/symposium_shell_upload.rb
@@ -16,12 +16,11 @@ class Wpxf::Exploit::SymposiumShellUpload < Wpxf::Module
             'file will allow the attacker to execute the script with the '\
             'privileges of the web server.',
       author: [
-          'Claudio Viviani', # Vulnerability disclosure
-          'Rob Carr <rob[at]rastating.com>' # WPXF module
+        'Claudio Viviani',                # Vulnerability disclosure
+        'Rob Carr <rob[at]rastating.com>' # WPXF module
       ],
       references: [
-          ['OSVDB', '116046'],
-          ['WPVDB', '7716']
+        ['WPVDB', '7716']
       ],
       date: 'Dec 11 2014'
     )


### PR DESCRIPTION
OSVDB has been shutdown and all OSVDB references are now dead - https://blog.osvdb.org/2016/04/05/osvdb-fin/